### PR TITLE
chore: Added `packed` as valid `category` value in `f-button`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.6 (Feb 13, 2024)
+
+### Improvements
+
+- Added `packed` as valid `category` value in `f-button`
+
+
 ## 1.3.5 (Aug 22, 2023)
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flow-intellisense-vscode",
   "displayName": "Flow Intellisense for flow design system",
   "description": "flow library intellisense for vscode [*.vue, *.html]",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "publisher": "dev-vikas",
   "repository": {
     "type": "git",

--- a/src/config/elements/f-button.json
+++ b/src/config/elements/f-button.json
@@ -36,6 +36,9 @@
           },
           "transparent": {
             "description": "No fill or border. Note: standard button padding will remain. Use f-text for a href/link "
+          },
+          "packed": {
+            "description": "Disaply without padding"
           }
         }
       },


### PR DESCRIPTION
### Checklist for raising a PR
- [x] All necessary unit tests added.
- [x] `config` folder is updated as per latest `@cldcvr/flow-*` versions. 
- [x] Did you check the contributing doc?
- [x] Did you check the existing issues for similar queries?


### Describe your PR

This will fix the below VS Code error


![image](https://github.com/ollionorg/flow-intellisense-vscode/assets/39631861/24c10b0b-2f0e-4a9e-a3bf-1b2af12d4be9)


![image](https://github.com/ollionorg/flow-intellisense-vscode/assets/39631861/1d875ba6-8612-4f53-bf27-4313a260fcd7)


### Add additional question here
- [ ] `Yes`
- [ ] `No`
- [ ] `NA`